### PR TITLE
Remove custom caddy runtime image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,0 @@
-ARG CADDY_VERSION=latest
-FROM docker.io/library/caddy:${CADDY_VERSION}-builder AS builder
-
-RUN xcaddy build
-
-FROM docker.io/library/caddy:${CADDY_VERSION}
-
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUNTIME ?= podman
-CADDY_IMAGE ?= caddy-mpl
+CADDY_IMAGE ?= docker.io/library/caddy
 CADDY_VERSION ?= 2.4.6
 
 serve:
@@ -11,12 +11,6 @@ serve:
 	    -p 2015:2015 \
 	    $(CADDY_IMAGE):$(CADDY_VERSION) \
 	    caddy run --config /etc/caddy/Caddyfile --watch
-
-image:
-	$(RUNTIME) build \
-	    --build-arg=CADDY_VERSION=$(CADDY_VERSION) \
-	    -t $(CADDY_IMAGE):$(CADDY_VERSION) \
-	    -f Containerfile
 
 fmt:
 	$(RUNTIME) run --rm -it \


### PR DESCRIPTION
We don't use any optional plugins any more, so don't need the custom image.